### PR TITLE
Issue [#454](https://github.com/livecomposer/live-composer-page-build…

### DIFF
--- a/css/frontend/modules.css
+++ b/css/frontend/modules.css
@@ -1138,9 +1138,14 @@ input[type="button"], input[type="submit"], input[type="reset"], input[type="fil
  * TEXT MODULE
  */
 
-	.dslc-text-module-content {
-		border: 0px solid transparent;
-	}
+.dslc-module-DSLC_Text_Simple img {
+	max-width: 100%;
+	height: auto;
+}
+
+.dslc-text-module-content {
+	border: 0px solid transparent;
+}
 
 /**
  * WIDGETS MODULE


### PR DESCRIPTION
…er/issues/454): Add height:auto into css to fix issues with image dimensions in WP editor 
Issue #454