### PR TITLE
Issue [#574](https://github.com/livecomposer/live-composer-page-build…

### DIFF
--- a/modules/infobox/module.php
+++ b/modules/infobox/module.php
@@ -820,7 +820,7 @@ class DSLC_Info_Box extends DSLC_Module {
 				'std' => '0',
 				'type' => 'slider',
 				'refresh_on_change' => false,
-				'affect_on_change_el' => '.dslc-info-box-image',
+				'affect_on_change_el' => '.dslc-info-box-image, .dslc-info-box-icon-pos-aside .dslc-info-box-image',
 				'affect_on_change_rule' => 'margin-right',
 				'section' => 'styling',
 				'tab' => __( 'Icon', 'live-composer-page-builder' ),


### PR DESCRIPTION
…er/issues/574): Infobox > Icon > Margin Right isn't working

#574