### PR TITLE
Restore inline-editor to Text-Simple

### DIFF
--- a/modules/text-simple/module.php
+++ b/modules/text-simple/module.php
@@ -5013,7 +5013,7 @@ class DSLC_Text_Simple extends DSLC_Module {
 		?><div class="dslc-text-module-content"><?php
 
 			if ( $dslc_active ) {
-				?><div class="dslca-editable-content" data-type="simple" data-id="content"<?php if ( $dslc_is_admin ) echo ' data-exportable-content'; ?>><?php
+				?><div class="dslca-editable-content inline-editor" data-type="simple" data-id="content"<?php if ( $dslc_is_admin ) echo ' data-exportable-content'; ?>><?php
 			}
 
 				$output_content = stripslashes( $options['content'] );


### PR DESCRIPTION
This was removed in July. I didn't find an explanation for the change in the commit, so I'm hoping this isn't disruptive. Our clients have become accustomed to the feature so we'd like to keep it if possible.