### PR TITLE
Add output filter for the Image module

### DIFF
--- a/modules/image/module.php
+++ b/modules/image/module.php
@@ -776,6 +776,8 @@ class DSLC_Image extends DSLC_Module {
 	 */
 	function output( $options ) {
 
+		ob_start();
+		
 		/* Module output starts here */
 
 		global $dslc_active;
@@ -937,5 +939,7 @@ class DSLC_Image extends DSLC_Module {
 		</div>
 		<?php
 
+		return apply_filters('dslc_image_render', ob_get_clean());
+		
 	}
 }


### PR DESCRIPTION
In order to speed up #951 , I've captured the output of the Image module and filtered it with `dslc_image_render`.

**Note:** This is all you'll need to merge to make lazyloading work (opt-in) in your plugin. I'll explain the process in #951 .