### PR TITLE
Fix some of the most common "Undefined array key" warnings in common code

### DIFF
--- a/includes/css-generation.php
+++ b/includes/css-generation.php
@@ -400,7 +400,7 @@ function dslc_module_gen_css( $atts, $settings_raw ) {
 
 		foreach ( $options_arr as $option_arr ) {
 
-			if ( 'image' === $option_arr['type'] ) {
+			if ( isset( $option_arr['type'] ) && 'image' === $option_arr['type'] ) {
 				if ( isset( $settings[ $option_arr['id'] ] ) && ! empty( $settings[ $option_arr['id'] ] ) && is_numeric( $settings[ $option_arr['id'] ] ) ) {
 					$dslc_var_image_option_bckp[ $option_arr['id'] ] = $settings[ $option_arr['id'] ];
 					$image_info = wp_get_attachment_image_src( $settings[ $option_arr['id'] ], 'full' );
@@ -409,7 +409,7 @@ function dslc_module_gen_css( $atts, $settings_raw ) {
 			}
 
 			// Fix css_custom value ( issue when default changed programmatically ).
-			if ( 'css_custom' === $option_arr['id'] && 'DSLC_Text_Simple' === $module_id && ! isset( $settings['css_custom'] ) ) {
+			if ( isset( $option_arr['id'] ) && 'css_custom' === $option_arr['id'] && 'DSLC_Text_Simple' === $module_id && ! isset( $settings['css_custom'] ) ) {
 				$settings['css_custom'] = $option_arr['std'];
 			}
 		}
@@ -576,7 +576,7 @@ function dslc_generate_module_css( $module_structure, $module_settings, $restart
 	// Transform module options into css rulles.
 	foreach ( $module_structure as $option_arr ) {
 
-		$option_id = $option_arr['id'];
+		$option_id = isset( $option_arr['id'] ) ? $option_arr['id'] : null;
 
 		// 🔖 RAW CODE CLEANUP
 		// if ( isset( $module_settings[ $option_id ] ) && ! empty( $module_settings[ $option_id ] )  ) {

--- a/includes/display-functions.php
+++ b/includes/display-functions.php
@@ -1098,7 +1098,7 @@ function dslc_module_front( $atts, $settings_raw = null, $is_header_footer = fal
 		// 🔖 RAW CODE CLEANUP
 		foreach ( $module_struct as $option ) {
 			// Fix 'Undefined index' notices.
-			if ( ! isset( $settings[ $option['id'] ] ) ) {
+			if ( isset( $option['id'] ) && ! isset( $settings[ $option['id'] ] ) ) {
 				$settings[ $option['id'] ] = false;
 			}
 		}
@@ -1109,7 +1109,7 @@ function dslc_module_front( $atts, $settings_raw = null, $is_header_footer = fal
 		// Transform image ID to URL
 		foreach ( $module_struct as $option ) {
 
-			if ( 'image' === $option['type'] ) {
+			if ( isset( $option['type'] ) && 'image' === $option['type'] ) {
 				if ( isset( $settings[ $option['id'] ] ) && ! empty( $settings[ $option['id'] ] ) && is_numeric( $settings[ $option['id'] ] ) ) {
 
 					$dslc_var_image_option_bckp[ $option['id'] ] = $settings[ $option['id'] ];


### PR DESCRIPTION
From PHP 8 onwards it warns if trying to access undefined array attributes. This change clears up some of the most common ones in common code (include/). This makes it much easier to debug the log file as it's not overrun by spurious warnings that often reoccur.